### PR TITLE
Fix warnings around signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 language: android
 android:
   components:
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
 script:
   - ./gradlew check jacoco assemble
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'org.ajoberstar:gradle-git:1.7.2'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ try {
 
 project.ext.minSdkVersion = 16
 project.ext.compileSdkVersion = 28
-project.ext.buildToolsVersion = '28.0.3'
 project.ext.supportLibVersion = '28.0.0'
 
 task showVersion {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'org.ajoberstar:gradle-git:1.7.2'
@@ -40,9 +40,9 @@ try {
 }
 
 project.ext.minSdkVersion = 16
-project.ext.compileSdkVersion = 27
-project.ext.buildToolsVersion = '27.0.3'
-project.ext.supportLibVersion = '27.1.1'
+project.ext.compileSdkVersion = 28
+project.ext.buildToolsVersion = '28.0.3'
+project.ext.supportLibVersion = '28.0.0'
 
 task showVersion {
     doLast {

--- a/config/android-common.gradle
+++ b/config/android-common.gradle
@@ -1,6 +1,5 @@
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.compileSdkVersion

--- a/config/javadoc.gradle
+++ b/config/javadoc.gradle
@@ -28,6 +28,6 @@ task javadocJar(type: Jar, dependsOn:androidJavadoc) {
 afterEvaluate {
     // fixes issue where javadoc can't find android symbols ref: http://stackoverflow.com/a/34572606
     androidJavadoc.classpath += files(android.libraryVariants.collect { variant ->
-        variant.javaCompile.classpath.files
+        variant.javaCompileProvider.get().classpath.files
     })
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 06 13:27:13 PDT 2018
+#Thu May 02 16:24:22 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/library/javatests/net/openid/appauth/CodeVerifierUtilTest.java
+++ b/library/javatests/net/openid/appauth/CodeVerifierUtilTest.java
@@ -14,7 +14,7 @@
 
 package net.openid.appauth;
 
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.security.SecureRandom;

--- a/library/javatests/net/openid/appauth/TokenResponseTest.java
+++ b/library/javatests/net/openid/appauth/TokenResponseTest.java
@@ -26,9 +26,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static net.openid.appauth.TestValues.TEST_APP_REDIRECT_URI;
 import static net.openid.appauth.TestValues.TEST_AUTH_CODE;
 import static net.openid.appauth.TestValues.TEST_CLIENT_ID;

--- a/library/javatests/net/openid/appauth/browser/BrowserSelectorTest.java
+++ b/library/javatests/net/openid/appauth/browser/BrowserSelectorTest.java
@@ -14,8 +14,8 @@
 
 package net.openid.appauth.browser;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static net.openid.appauth.browser.BrowserSelector.BROWSER_INTENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;


### PR DESCRIPTION
This commit upgrades build tools and fixes warnings about deprecated code.
Not all warnings were fixed here. There are 3 about signatures in PackageInfo but they are used in test.